### PR TITLE
Handle observer when property isn't declare in properties

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,2 @@
+[*.ts]
+indent_size = 2

--- a/src/annotations/index.ts
+++ b/src/annotations/index.ts
@@ -69,7 +69,9 @@ export function observe({ config, propertiesMap, observers, params }: Annotation
     observedProps = config.params.map(param => param.name);
   }
 
-  if (observedProps.length === 1 && observedProps[ 0 ].includes(".") === false) {
+  const isPropertyDeclared = propertiesMap.has(observedProps[ 0 ]);
+
+  if (isPropertyDeclared && observedProps.length === 1 && observedProps[ 0 ].includes(".") === false) {
     propertiesMap.get(observedProps[ 0 ]).observer = `"${config.name}"`;
   }
   else {


### PR DESCRIPTION
The `@observe` decorator throws on [this line](https://github.com/Draccoz/twc/blob/master/src/annotations/index.ts#L73) when you define an element as shown below because obserever property cannot be found in.

``` ts
export class ObserveMissing {
   @observe
   someObserver(noSuchProp) {
   }
}
```

I was about to create a PR for this by simply throwing a more helpful error but I think that it's not actually correct. After all, it is also possible to observe properties only ever declared in the template. Such that never appear in `properties: {}`.

In this case the observer should be added to `observers`:

``` js
Polymer({
   observers: [
      'someObserver(noSuchProp)'
   ]
});
```