### PR TITLE
Running for directory should preserve paths (#51): changing paths and structure to match TypeScript CLI behavior

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,26 +1,45 @@
 #!/usr/bin/env node
 
-import { join } from "path";
-import { src, dest } from "gulp";
 import program = require("commander");
+import { join, parse } from "path";
+import { src, dest } from "gulp";
 import twc = require("./index");
 
 if (require.main === module) {
+  let files = null;
   program
-    .option("-t, --ts-config <path>", "tsconfig.json file location")
-    .option("-b, --bower-config <path>", "bower.json file location")
-    .option("-o, --out-dir <path>", "Output file")
+    .option("-p, --tsConfig <path>", "tsconfig.json file location")
+    .option("-b, --bowerConfig <path>", "bower.json file location")
+    .option("-o, --outDir <path>", "Redirect output structure to the directory.")
+    .option("-r, --rootDir <path>",
+      "Specify the root directory of input files. Use to control the output directory structure with --out-dir.")
+    .arguments("<sources...>")
+    .action(sources => files = sources)
     .parse(process.argv);
 
   let cwd = process.cwd();
-  let files = program.args;
+  const fullPath = path => path ? join(cwd, path) : undefined;
+
+  let base = fullPath(program[ "rootDir" ]);
+
+  if (!base) {
+    // calculate the rootDir if it wasn't provided via --rootDir (tsc style, longest common prefix)
+    base = files.map(file => parse(file).dir).reduce((a, b) => {
+      let A = [ a, b ].concat().sort(),
+        a1 = A[ 0 ], a2 = A[ A.length - 1 ], L = a1.length, i = 0;
+      while (i < L && a1.charAt(i) === a2.charAt(i)) {
+        i++;
+      }
+      return a1.substring(0, i);
+    });
+  }
 
   console.time("Done");
-  twc(src(files.length === 0 ? [ "*.ts" ] : files, { cwd }), {
-    tsConfigPath: program[ "tsConfig" ] ? join(process.cwd(), program[ "tsConfig" ]) : undefined,
-    bowerConfigPath: program[ "bowerConfig" ] ? join(process.cwd(), program[ "bowerConfig" ]) : undefined
+  twc(src(files || [ "*.ts" ], { cwd, base }), {
+    tsConfigPath: fullPath(program[ "tsConfig" ]),
+    bowerConfigPath: fullPath(program[ "bowerConfig" ])
   })
-    .pipe(dest(program[ "outDir" ] || "out", { cwd }))
+    .pipe(dest(program[ "outDir" ] || base))
     .on("finish", () => {
       console.timeEnd("Done");
       process.exit(0);


### PR DESCRIPTION
Running for directory should preserve paths (#51): changing paths and structure to match TypeScript CLI behavior